### PR TITLE
Add EV Charging to Amenities menu

### DIFF
--- a/cms_legacy/front_matter/templates/lodging.yml
+++ b/cms_legacy/front_matter/templates/lodging.yml
@@ -52,6 +52,7 @@ fields:
     - 4 - Pool/Hot Tub
     - 5 - Pet Friendly
     - 6 - WiFi Available
+    - 11 - EV Charging
     - 7 - Kitchens Available
     - 8 - Meeting Facilities
     - 9 - Handicap Accessible


### PR DESCRIPTION
Fixes #283

This is the only place where I see EV Charging is not listed among others in the list